### PR TITLE
register page button design on typhoid-screener-app

### DIFF
--- a/Mariam Abdihakim Osman/Task2.md
+++ b/Mariam Abdihakim Osman/Task2.md
@@ -1,0 +1,3 @@
+## Typhoid-screener-App the register page button had UI issue and I fixed.
+
+## here is the link of the Pull request I made on Typhoid-screener-App repository https://github.com/ps-19/Typhoid-screener-App/pull/8


### PR DESCRIPTION
I fixed the UI design for button register page on typhoid-screener-app. 
here is the link of my PR on the typhoid-screener-app repository ( https://github.com/ps-19/Typhoid-screener-App/pull/8)

the same link I provided task2.md inside the folder with the name [Mariam Abdihakim Osman]
